### PR TITLE
[infra] Add optional claude-desktop app to desktop-apps role

### DIFF
--- a/roles/desktop-apps/tasks/claude-desktop-repo.yml
+++ b/roles/desktop-apps/tasks/claude-desktop-repo.yml
@@ -1,0 +1,44 @@
+---
+# Claude Desktop (beta) from Anthropic's apt repository.
+# https://code.claude.com/docs/en/desktop-linux
+#
+# The claude-desktop package self-manages an *active* repository file
+# /etc/apt/sources.list.d/claude-desktop.list (signed-by a different keyring under
+# /usr/share/keyrings), controlled by CLAUDE_DESKTOP_ADD_REPO in
+# /etc/default/claude-desktop. Left enabled it duplicates the deb822
+# claude-desktop.sources managed here, and apt aborts every operation with
+# "Conflicting values set for option Signed-By". So, like Chrome and Slack, we turn
+# the package's repo self-management off and own the definition ourselves. These
+# tasks run (via the include in debian.yml) BEFORE the package is installed, so a
+# fresh install's postinst sees the flag off and writes no claude-desktop.list.
+- name: Stop claude-desktop reconfiguring its own apt repo (managed via claude-desktop.sources)
+  copy:
+    dest: /etc/default/claude-desktop
+    content: |
+      # Managed by ansible. The Claude Desktop apt repository is configured via the
+      # deb822 file /etc/apt/sources.list.d/claude-desktop.sources. This setting stops
+      # the claude-desktop package from re-adding its own claude-desktop.list, which
+      # would duplicate that source and break apt with a "Conflicting values set for
+      # option Signed-By" error.
+      CLAUDE_DESKTOP_ADD_REPO="false"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Remove claude-desktop's self-managed claude-desktop.list (repo is configured via claude-desktop.sources)
+  file:
+    path: /etc/apt/sources.list.d/claude-desktop.list
+    state: absent
+
+- name: Add Claude Desktop (Anthropic) repository
+  deb822_repository:
+    name: claude-desktop
+    types: deb
+    uris: https://downloads.claude.ai/claude-desktop/apt/stable
+    suites: stable
+    components: main
+    architectures:
+      - amd64
+      - arm64
+    signed_by: https://downloads.claude.ai/claude-desktop/key.asc
+  register: claude_desktop_repo

--- a/roles/desktop-apps/tasks/debian.yml
+++ b/roles/desktop-apps/tasks/debian.yml
@@ -50,6 +50,12 @@
   when: >
     'dropbox' in all_desktop_packages
 
+- name: Add Claude Desktop repository
+  include_tasks:
+    file: claude-desktop-repo.yml
+  when: >
+    'claude-desktop' in all_desktop_packages
+
 - name: Update apt cache when a desktop repository changed
   apt:
     update_cache: yes
@@ -58,6 +64,7 @@
     or (spotify_repo is defined and spotify_repo is changed)
     or (sublime_repo is defined and sublime_repo is changed)
     or (dropbox_repo is defined and dropbox_repo is changed)
+    or (claude_desktop_repo is defined and claude_desktop_repo is changed)
 
 - name: Install desktop packages
   apt:


### PR DESCRIPTION
# Description

Adds optional support for Anthropic's Claude Desktop app (Linux beta) to the `desktop-apps` role. It is opt-in: the repository and package are only configured when `claude-desktop` is present in `desktop_extra_packages`, matching the existing pattern for `sublime-text` and `dropbox`. There is no dedicated toggle variable.

The non-obvious part is repository management. Contrary to the upstream docs (which claim the package writes a *commented-out* source), the `claude-desktop` package self-manages an **active** `/etc/apt/sources.list.d/claude-desktop.list`, signed by a keyring under `/usr/share/keyrings`. That duplicates the ansible-managed deb822 `claude-desktop.sources` (signed by `/etc/apt/keyrings/claude-desktop.asc`) and makes apt abort every operation with `E: Conflicting values set for option Signed-By`. Following the same approach already used for Chrome and Slack, the new `claude-desktop-repo.yml` disables the package's repo self-management by writing `CLAUDE_DESKTOP_ADD_REPO="false"` to `/etc/default/claude-desktop` and removes the vendor `.list` before adding our own source. These steps run before any apt operation in the role, so the role is self-healing and idempotent.

Tested end-to-end on an Ubuntu host: `claude-desktop` installs from `downloads.claude.ai`, `apt-cache policy` resolves a single conflict-free source, and re-running the role is idempotent.

## Test Plan

The following tests will be performed and expected to pass:
- [x] Super-linter
- [x] Ansible-test
- [x] Any other automatically triggered GitHub test workflows

## Author tasks

- Add documentation if necessary
- Add tests where appropriate
